### PR TITLE
Add support for xkb-switch

### DIFF
--- a/autoload/barbaric.vim
+++ b/autoload/barbaric.vim
@@ -46,6 +46,8 @@ endfunction
 function! barbaric#get_im()
   if g:barbaric_ime == 'macos'
     return system('xkbswitch -g')
+  elseif g:barbaric_ime == 'xkb-switch'
+    return libcall(g:XkbSwitchLib, 'Xkb_Switch_getXkbLayout', '')
   elseif g:barbaric_ime == 'fcitx'
     return system('fcitx-remote') == 2 ? '-o' : '-c'
   elseif g:barbaric_ime == 'ibus'
@@ -65,6 +67,8 @@ endfunction
 function! s:set_im(im)
   if g:barbaric_ime == 'macos'
     silent call system('xkbswitch -s ' . a:im)
+  elseif g:barbaric_ime == 'xkb-switch'
+    call libcall(g:XkbSwitchLib, 'Xkb_Switch_setXkbLayout', a:im)
   elseif g:barbaric_ime == 'fcitx'
     silent call system('fcitx-remote ' . a:im)
   elseif g:barbaric_ime == 'ibus'

--- a/plugin/barbaric.vim
+++ b/plugin/barbaric.vim
@@ -1,6 +1,12 @@
 " Check dependencies
 if has('mac') && executable('xkbswitch')
   let g:barbaric_ime = 'macos'
+elseif filereadable('/usr/lib/libxkbswitch.so')
+  let g:XkbSwitchLib = "/usr/lib/libxkbswitch.so"
+  let g:barbaric_ime = 'xkb-switch'
+elseif filereadable('/lib/libxkbswitch.so')
+  let g:XkbSwitchLib = "/lib/libxkbswitch.so"
+  let g:barbaric_ime = 'xkb-switch'
 elseif executable('fcitx-remote') && system('fcitx-remote') > 0
   let g:barbaric_ime = 'fcitx'
 elseif executable('ibus')


### PR DESCRIPTION
I added support for switching layouts using the library from https://github.com/ierton/xkb-switch. Since it can be called directly rather than going through the shell it has the advantage that you don't have to worry about escaping brackets in variant layout names like 'gr(polytonic)'.