### PR TITLE
An unset variable be unleted when vim start

### DIFF
--- a/autoload/barbaric.vim
+++ b/autoload/barbaric.vim
@@ -37,7 +37,9 @@ endfunction
 function! s:record_im()
   let l:im = barbaric#get_im()
   if l:im == g:barbaric_default
-    execute 'silent! unlet ' . s:im_varname()
+    if exists(s:im_varname)
+      execute 'silent! unlet ' . s:im_varname()
+    endif
   else
     execute "silent! let " . s:im_varname() . " = '" . l:im . "'"
   endif

--- a/autoload/barbaric.vim
+++ b/autoload/barbaric.vim
@@ -37,7 +37,7 @@ endfunction
 function! s:record_im()
   let l:im = barbaric#get_im()
   if l:im == g:barbaric_default
-    if exists(s:im_varname)
+    if exists(s:im_varname())
       execute 'silent! unlet ' . s:im_varname()
     endif
   else


### PR DESCRIPTION
OS: archlinux
IME: fcitx5
minimum .vimrc

call plug#begin('~/.vim/plugged')
Plug 'rlue/vim-barbaric'
call plug#end()

vimlog

Error detected while processing function barbaric#switch[2]..<SNR>25_record_im:
line    3:
E108: No such variable: "b:barbaric_current"
Executing command: "'/usr/bin/zsh' '-c' 'fcitx5-remote -c'"

solution:

I add a check when unlet the barbaric_current.
