### PR TITLE
update xkbswitch-macosx README reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Vim doesn’t play nicely with non-Latin scripts; _i.e.,_ input languages of non
 
 ### Supported IMEs
 
-* macOS (requires [xkbswitch-macosx](https://github.com/myshov/xkbswitch-macosx))
+* macOS (requires [xkbswitch-macosx](https://github.com/xiehuc/xkbswitch-macosx))
 
   ```sh
   # Install via:
-  $ curl -o /usr/local/bin/xkbswitch https://raw.githubusercontent.com/myshov/xkbswitch-macosx/master/bin/xkbswitch
+  $ curl -L -o /usr/local/bin/xkbswitch https://github.com/xiehuc/xkbswitch-macosx/releases/download/v0.1.0/xkbswitch
   ```
 
 * fcitx
@@ -91,7 +91,7 @@ Troubleshooting
 
   ```viml
   " .vimrc
-
+  
   set ttimeoutlen=0
   ```
 


### PR DESCRIPTION
original xkbswitch-macosx's code is full of bug and hard to understand.

for eample:

1. it use input source list index as an id, makes id differs on
   different machine
2. it show layout by hard code it. just couldn't know why
3. it couldn't set im.rime.inputmethod.Squirrel.Rime because it believes
   every sourceid has an com.apple prefix and hard code it.

so i modify it (copy from https://github.com/minoki/InputSourceSelector,
change api, which earlier and better)