### PR TITLE
ftr: Support macism (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,11 @@ Vim doesn’t play nicely with non-Latin scripts; _i.e.,_ input languages of non
 
 ### Supported IMEs
 
-* macOS (requires [xkbswitch-macosx](https://github.com/myshov/xkbswitch-macosx))
-
-  ```sh
-  # Install via:
-  $ curl -o /usr/local/bin/xkbswitch https://raw.githubusercontent.com/myshov/xkbswitch-macosx/master/bin/xkbswitch
-  ```
-
-* fcitx
-* ibus
-* [xkb-switch](https://github.com/grwlf/xkb-switch)
+* 🍎 [macism](https://github.com/laishulu/macism)
+* 🍎 [xkbswitch-macosx](https://github.com/myshov/xkbswitch-macosx) (⚠️ [buggy](https://github.com/myshov/xkbswitch-macosx/issues/5))
+* 🐧 fcitx
+* 🐧 ibus
+* 🐧 [xkb-switch](https://github.com/grwlf/xkb-switch)
 
 If you need support for another IME or input system, consider:
 

--- a/autoload/barbaric.vim
+++ b/autoload/barbaric.vim
@@ -46,7 +46,9 @@ function! s:record_im()
 endfunction
 
 function! barbaric#get_im()
-  if g:barbaric_ime == 'macos'
+  if g:barbaric_ime == 'macism'
+    silent return system('macism')
+  elseif g:barbaric_ime == 'mac-xkbswitch'
     silent return system('xkbswitch -g')
   elseif g:barbaric_ime == 'xkb-switch'
     return libcall(g:barbaric_libxkbswitch, 'Xkb_Switch_getXkbLayout', '')
@@ -67,7 +69,9 @@ function! s:restore_insert_im()
 endfunction
 
 function! s:set_im(im)
-  if g:barbaric_ime == 'macos'
+  if g:barbaric_ime == 'macism'
+    silent call system('macism ' . a:im)
+  elseif g:barbaric_ime == 'mac-xkbswitch'
     silent call system('xkbswitch -s ' . a:im)
   elseif g:barbaric_ime == 'xkb-switch'
     call libcall(g:barbaric_libxkbswitch, 'Xkb_Switch_setXkbLayout', a:im)

--- a/plugin/barbaric.vim
+++ b/plugin/barbaric.vim
@@ -22,8 +22,10 @@ endif
 if !exists('g:barbaric_ime')
   silent let g:barbaric_uname = substitute(system('uname'), '\n', '', '')
 
-  silent if g:barbaric_uname == 'Darwin' && executable('xkbswitch')
-    let g:barbaric_ime = 'macos'
+  silent if executable('macism')
+    let g:barbaric_ime = 'macism'
+  elseif g:barbaric_uname == 'Darwin' && executable('xkbswitch')
+    let g:barbaric_ime = 'mac-xkbswitch'
   elseif exists('g:barbaric_libxkbswitch')
     let g:barbaric_ime = 'xkb-switch'
   elseif exists('g:barbaric_fcitx_cmd') && system(g:barbaric_fcitx_cmd) > 0


### PR DESCRIPTION
macism resolves a long-standing bug present in virtually all other CLI IME switchers for macOS. This commit adds support and gives it precedence over xkbswitch-macosx.